### PR TITLE
Accept zero results if -c and -w and both zero

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ check_sphinxsearch_query -w <warn> -c <crit> -H <server IP/Name> -q <query> -t <
   -w (--warning)   = Min. number of results in queue to generate warning
   -c (--critical)  = Min. number of results in queue to generate critical alert ( w < c )
   -q (--query) = ('Prague' by default)
-  -H (--host) = Server name or IP(default 127.0.0.1) 
+  -H (--host) = Server name, IP address, or path to Unix socket (default 127.0.0.1)
   -t (--timeout)  = Set server connection timeout(1000 by default).
   -h (--help)
 Example: ./check_sphinxsearch_query -w 200 -c 150 -H localhost -q why

--- a/check_sphinxsearch_query
+++ b/check_sphinxsearch_query
@@ -114,7 +114,7 @@ return $ERRORS{'OK'};
 }
 
 sub print_usage () {
-        print "Usage: check_sphinx_query -w <warn> -c <crit> -H <server IP/Name> -q <query> -t <timeout>\n";
+        print "Usage: check_sphinx_query -w <warn> -c <crit> -H <server IP/Name/path to socket> -q <query> -t <timeout>\n";
 }
 
 sub print_help () {
@@ -131,7 +131,7 @@ sub print_help () {
         print "-w (--warning)   = Min. number of results in queue to generate warning\n";
         print "-c (--critical)  = Min. number of results in queue to generate critical alert ( w > c )\n";
         print "-q (--query) = 'Prague' by default\n";
-        print "-H (--host) = Server name or IP(default 127.0.0.1)\n";
+        print "-H (--host) = Server name, IP address, or path to Unix socket (default 127.0.0.1)\n";
         print "-t (--timeout)  = Set server connection timeout(1000 by default).\n";
         print "-h (--help)\n";
         print "\n\n"; 

--- a/check_sphinxsearch_query
+++ b/check_sphinxsearch_query
@@ -87,7 +87,7 @@ sub process_arguments(){
                 print_help();
                 exit $ERRORS{'OK'};
         }
-        if ( $opt_w <= $opt_c) {
+        if (($opt_w || $opt_c) && $opt_w <= $opt_c) {
             print "Sphinxsearch query UNKNOWN:  (-w '$opt_w') cannot be smaller than Critical (-c '$opt_c'). \n";
                 exit $ERRORS{'UNKNOWN'};
         }
@@ -127,6 +127,8 @@ sub print_help () {
         print "   Ask for query on all indexes and use total founded.\n";
         print "   If CRITICAL are less then total founded, then CRITICAL.\n";
         print "   If WARNING are less then total founded, then WARNING.\n";
+        print "   If CRITICAL and WARNING are both zero, return OK for any\n";
+        print "   number of results (including zero).\n";
         print "";
         print "-w (--warning)   = Min. number of results in queue to generate warning\n";
         print "-c (--critical)  = Min. number of results in queue to generate critical alert ( w > c )\n";


### PR DESCRIPTION
It's sometimes useful just to monitor that `searchd` is alive, and not care if we get results or not, so I've allowed `-w` and `-c` to both be zero.

I've also added some text to the `-H` description to say that a path to a Unix socket is an acceptable argument.
